### PR TITLE
Require hashable >= 1.2.5.0 for `Hashed`

### DIFF
--- a/quickcheck-instances.cabal
+++ b/quickcheck-instances.cabal
@@ -50,7 +50,7 @@ Library
     bytestring           >=0.9     && <0.11,
     case-insensitive     >=1.2.0.4 && <1.3,
     containers           >=0.3     && <0.6,
-    hashable             >=1.1.2.3 && <1.3,
+    hashable             >=1.2.5.0 && <1.3,
     old-time             >=1.0     && <1.2,
     scientific           >=0.2     && <0.4,
     tagged               >=0.8.5   && <0.9,


### PR DESCRIPTION
I filed a revision: https://hackage.haskell.org/package/quickcheck-instances-0.3.16/revisions/