### PR TITLE
Generate interesting Days and UniversalTimes

### DIFF
--- a/src/Test/QuickCheck/Instances.hs
+++ b/src/Test/QuickCheck/Instances.hs
@@ -259,7 +259,7 @@ instance Arbitrary1 Tree.Tree where
                 rest <- arbPartition $ k - first
                 return $ first : rest
 
-    liftShrink shr = go 
+    liftShrink shr = go
       where
         go (Tree.Node val forest) = forest ++
             [ Tree.Node e fs
@@ -352,7 +352,10 @@ instance CoArbitrary OldTime.CalendarTime where
 -------------------------------------------------------------------------------
 
 instance Arbitrary Time.Day where
-    arbitrary = Time.ModifiedJulianDay <$> (2000 +) <$> arbitrary
+    arbitrary = sized $ \n -> do
+      let limit = (toInteger n)*365
+      offset <- choose (-limit, limit)
+      return $ Time.addDays offset (Time.fromGregorian 2000 1 1)
     shrink    = (Time.ModifiedJulianDay <$>) . shrink . Time.toModifiedJulianDay
 
 instance CoArbitrary Time.Day where
@@ -362,7 +365,10 @@ instance Function Time.Day where
     function = functionMap Time.toModifiedJulianDay Time.ModifiedJulianDay
 
 instance Arbitrary Time.UniversalTime where
-    arbitrary = Time.ModJulianDate <$> (2000 +) <$> arbitrary
+    arbitrary = sized $ \n -> do
+      let limit = (fromIntegral n)*365.25 :: Double
+      offset <- toRational <$> choose (-limit, limit)
+      return $ Time.ModJulianDate $ toRational (Time.toModifiedJulianDay (Time.fromGregorian 2000 1 1)) + offset
     shrink    = (Time.ModJulianDate <$>) . shrink . Time.getModJulianDate
 
 instance CoArbitrary Time.UniversalTime where


### PR DESCRIPTION
Previously the range of generated `Day` values was `size` days before and after 1864-5-8, i.e. about two months in the late nineteenth century. That's both too narrow (only covering part of the year) and doesn't intersect any of the dates which are likely to be of interest to most users of these types.

This makes the range `size` _years_, centered on 2000-1-1. With the typical size, that covers most of the era of modern computing and about a decade into the future.

Note: the Day instance is also used to generate LocalDates, UTCTimes, etc., so they also benefit.