### PR TITLE
Backport ShortByteString instances using bytestring-builder

### DIFF
--- a/quickcheck-instances.cabal
+++ b/quickcheck-instances.cabal
@@ -65,6 +65,7 @@ Library
     array                >=0.4.0.0 && <0.6,
     base-compat          >=0.9.3   && <0.10,
     bytestring           >=0.9.2.1 && <0.11,
+    bytestring-builder   >=0.10.4  && <0.11,
     case-insensitive     >=1.2.0.4 && <1.3,
     containers           >=0.4.2.1 && <0.6,
     hashable             >=1.2.5.0 && <1.3,

--- a/src/Test/QuickCheck/Instances/ByteString.hs
+++ b/src/Test/QuickCheck/Instances/ByteString.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Test.QuickCheck.Instances.ByteString () where
@@ -10,9 +9,7 @@ import Test.QuickCheck
 
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BL
-#if MIN_VERSION_bytestring(0,10,4)
 import qualified Data.ByteString.Short as SBS
-#endif
 
 -------------------------------------------------------------------------------
 -- bytestring
@@ -40,7 +37,6 @@ instance Function BL.ByteString where
     function = functionMap BL.unpack BL.pack
 
 
-#if MIN_VERSION_bytestring(0,10,4)
 instance Arbitrary SBS.ShortByteString where
     arbitrary = SBS.pack <$> arbitrary
     shrink xs = SBS.pack <$> shrink (SBS.unpack xs)
@@ -50,4 +46,3 @@ instance CoArbitrary SBS.ShortByteString where
 
 instance Function SBS.ShortByteString where
     function = functionMap SBS.unpack SBS.pack
-#endif


### PR DESCRIPTION
I recently attempted to upgrade my `text-show` package's test suite to use the new instances for `ShortByteString` from `quickcheck-instances-0.3.17`. However, I was dismayed to discover that they were only defined for certain recent versions of `bytestring`! This led to the Travis failure seen [here](https://travis-ci.org/RyanGlScott/text-show).

This PR makes these `ShortByteString` instances defined on all supported versions of GHC by using the `bytestring-builder` compatibility package.