### PR TITLE
Arbitrary Tree: choose the number of nodes at random.

### DIFF
--- a/src/Test/QuickCheck/Instances/Containers.hs
+++ b/src/Test/QuickCheck/Instances/Containers.hs
@@ -17,12 +17,14 @@ import qualified Data.Tree as Tree
 -------------------------------------------------------------------------------
 
 instance Arbitrary1 Tree.Tree where
-    liftArbitrary arb = go
+    liftArbitrary arb = sized $ \n -> do
+        k <- choose (0, n)
+        go k
       where
-        go = sized $ \n -> do -- Sized is the size of the trees.
+        go n = do -- n is the size of the trees.
             value <- arb
             pars <- arbPartition (n - 1) -- can go negative!
-            forest <- for pars $ \i -> resize i go
+            forest <- for pars $ \i -> go i
             return $ Tree.Node value forest
 
         arbPartition :: Int -> Gen [Int]


### PR DESCRIPTION
Currently, the number of nodes in a generated `Tree` is exactly equal to the size parameter. This means that for example the following property will pass:

```
prop_sameLength :: Tree Int -> Tree Int -> Property
prop_sameLength x y = length x === length y
```

This patch fixes that by choosing the number of nodes uniformly in the range 0..size (the same as how the `Arbitrary` instance for lists works).