### PR TITLE
Corrects changelog version typo (0.3.33 -> 0.3.23)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,4 @@
-0.3.33
+0.3.23
 
 * Add `these` instances.
 


### PR DESCRIPTION
Looks like there was a minor typo in the changelog, the latest published library version is `0.3.23` rather than `0.3.33`.